### PR TITLE
Fix reference for filters in options

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -135,7 +135,6 @@
     "no-empty-character-class": 2, // - disallow the use of empty character classes in regular expressions
     "no-ex-assign": 2, // - disallow assigning to the exception in a catch block
     "no-extra-boolean-cast": 2, // - disallow double-negation boolean casts in a boolean context
-    "no-extra-parens": 2, // - disallow unnecessary parentheses (off by default)
     "no-extra-semi": 2, // - disallow unnecessary semicolons
     "no-func-assign": 2, // - disallow overwriting functions written as function declarations
     "no-inner-declarations": 2, // - disallow function or variable declarations in nested blocks
@@ -143,7 +142,6 @@
     "no-negated-in-lhs": 2, // - disallow negation of the left operand of an in expression
     "no-obj-calls": 2, // - disallow the use of object properties of the global object (Math and JSON) as functions
     "no-regex-spaces": 2, // - disallow multiple spaces in a regular expression literal
-    "quote-props": [2, "always"], // - disallow reserved words being used as object literal keys (off by default)
     "no-sparse-arrays": 2, // - disallow sparse arrays
     "no-unreachable": 2, // - disallow unreachable statements after a return, throw, continue, or break statement
     "use-isnan": 2, // - disallow comparisons with the value NaN

--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -114,8 +114,8 @@ Mailer.send = function (options, cb) {
         sendgridEmail.addFile(fileConfig);
       }, options.files);
     }
-    if (this.filters) {
-      sendgridEmail.setFilters(this.filters);
+    if (sendgridFilters) {
+      sendgridEmail.setFilters(sendgridFilters);
     }
 
     connector.sendgrid.send(sendgridEmail, fn);

--- a/package.json
+++ b/package.json
@@ -40,17 +40,17 @@
       "stats": {
         "lines": {
           "pctSkipped": 0,
-          "pct": 77,
+          "pct": 75,
           "colour": "yellow"
         },
         "branches": {
           "pctSkipped": 0,
-          "pct": 42,
+          "pct": 48,
           "colour": "yellow"
         },
         "statements": {
           "pctSkipped": 0,
-          "pct": 77,
+          "pct": 75,
           "colour": "yellow"
         },
         "functions": {
@@ -83,6 +83,7 @@
     "build": "Build"
   },
   "dependencies": {
+    "babel-core": "^6.10.4",
     "q": "^1.4.1",
     "ramda": "^0.21.0",
     "sendgrid": "^3.0.4"


### PR DESCRIPTION
This fixes filters reference to the higher scoped var sendgridFilters, instead of `this.filters`, which is always undefined in this context. There were a couple of repeated eslintrc rules as well. 