### PR TITLE
Correct Faulty 'to' parsing

### DIFF
--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -97,24 +97,39 @@ Mailer.send = function (options, cb) { // eslint-disable-line
 
     //email to param
     if (R.is(String, options.to)) {
-      sendgridMessage.to = R.map(
-        function(email) {
+      options.to = R.map(
+        function unwrapEmailString(email) {
           return {"email": email};
         },
-        options.to.split(',')
+        options.to.split([',', ';'])
       );
-    } else if (R.is(Object, options.to)) {
-      sendgridMessage.to = [options.to];
-    } else {
-      sendgridMessage.to = options.to;
     }
+
+    if (R.is(Object, options.to) && !R.is(Array, options.to)) {
+      options.to = [options.to];
+    }
+
+    if (R.is(Array, options.to)) {
+      sendgridMessage.to = R.map(
+        function unwrapArrayString(recipient) {
+          if (R.is(String, recipient)) {
+            recipient = {"email": recipient};
+          }
+          return new helper.Email(recipient.email, recipient.name);
+        },
+        options.to
+      );
+    } else {
+      throw new Error('invalid format for "to"');
+    }
+
     delete options.to;
 
     //basic sendgrid email
     sendgridEmail = new helper.Mail(
       new helper.Email(sendgridMessage.from, sendgridMessage.fromname),
       options.subject,
-      new helper.Email(sendgridMessage.to),
+      sendgridMessage.to[0], // needs major refactoring to send to each 'to'
       new helper.Content("text/plain", options.text || '')
     );
     if (options.html) {
@@ -203,14 +218,15 @@ Mailer.send = function (options, cb) { // eslint-disable-line
     request.path = '/v3/mail/send';
     request.body = sendgridEmail.toJSON();
     connector.sendgrid.API(request, function sgCb(response){ // eslint-disable-line
-      if (response.statusCode === 200 || response.statusCode === "200") {
+      var code = response && response.statusCode;
+      if (code && (code.toString() === 200 || code.toString() === 202)) {
         fn(null, response);
       } else {
         fn(response);
       }
     });
   } else {
-    process.nextTick(function () {
+    process.nextTick(function nextTick() { // eslint-disable-line
       fn(null, options);
     });
   }
@@ -221,7 +237,7 @@ Mailer.send = function (options, cb) { // eslint-disable-line
  * Send an email instance using instance
  */
 
-Mailer.prototype.send = function (fn) {
+Mailer.prototype.send = function protoSend(fn) {
   return this.constructor.send(this, fn);
 };
 

--- a/package.json
+++ b/package.json
@@ -40,30 +40,30 @@
       "stats": {
         "lines": {
           "pctSkipped": 0,
-          "pct": 58,
+          "pct": 59,
           "colour": "yellow"
         },
         "branches": {
           "pctSkipped": 0,
-          "pct": 30,
+          "pct": 38,
           "colour": "yellow"
         },
         "statements": {
           "pctSkipped": 0,
-          "pct": 58,
+          "pct": 59,
           "colour": "yellow"
         },
         "functions": {
           "pctSkipped": 0,
-          "pct": 44,
+          "pct": 47,
           "colour": "yellow"
         },
         "skipped": {
           "pct": 0
         },
         "overall": {
-          "pct": 48,
-          "colour": "red"
+          "pct": 51,
+          "colour": "yellow"
         }
       }
     }


### PR DESCRIPTION
Addresses the 'to' issue outlined in #10 and #13 

---

The sendgrid library that this connector is using will only accept one
'to' recipient at a time, and only with a very specific format.
Previously, any 'to' string was being parsed into an array, and then
passed to the sendgrid library where it would fail.  That's annoying.

This fixes the parsing logic to ensure that we're only sending one email
at a time, and only sends the first email.  This may be slightly
sub-optimal, but at least it works.  Futher refactoring should allow us
to send a separate email to each recipient.

---

I did notice that there seem to be some tests failing, but I can't for the life of me figure out what it is.  In any case this fixes things for my own use, so I hope we can sort out what the issue with the tests is and get this out.