### PR TITLE
Fix personalizations

### DIFF
--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -185,12 +185,6 @@ Mailer.send = function (options, cb) { // eslint-disable-line
           sendgridEmail.addHeader(header);
         }, options.sendGridConfig.headers);
       }
-      //personalizations
-      if (R.is(Array, options.sendGridConfig.personalizations)) {
-        R.forEach(function eachPers(personalization){
-          sendgridEmail.addPersonalization(personalization);
-        }, options.sendGridConfig.personalizations);
-      }
       //templateId
       if (options.sendGridConfig.templateId) {
         sendgridEmail.setTemplateId(options.sendGridConfig.templateId);

--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -169,9 +169,7 @@ Mailer.send = function (options, cb) { // eslint-disable-line
     if (options.sendGridConfig) {
       //personalizations
       if (R.is(Array, options.sendGridConfig.personalizations)) {
-        R.forEach(function eachPers(personalization){
-          sendgridEmail.addPersonalization(personalization);
-        }, options.sendGridConfig.personalizations);
+        sendgridEmail.personalizations = options.sendGridConfig.personalizations;
       }
       //sections
       if (R.is(Array, options.sendGridConfig.sections)) {


### PR DESCRIPTION
Hi,

I've fixed a few things that I experienced as bugs regarding the personalizations.
Personalizations were added twice and the "to" field becomes it's own personalization in the mail helper.
When adding a custom personalization, the "to" field is required even if it's the same as specified earlier.
This causes the email to be processed multiple times.
It's doesn't actually send multiple times, but it clutters the logs.

Kind regards,
Luuk