### PR TITLE
Add unique_args to sendgrid config

### DIFF
--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -213,6 +213,13 @@ Mailer.send = function (options, cb) { // eslint-disable-line
           sendgridEmail.addCategory(category);
         }, options.sendGridConfig.categories);
       }
+      //unique_args
+      if (R.is(Array, options.sendGridConfig.unique_args)) {
+        R.forEach(function eachUniqueArg(arg){
+          sendgridEmail.addUniqueArg(arg);
+        }, options.sendGridConfig.unique_args);
+      }
+      
     }
     request = connector.sendgrid.emptyRequest();
     request.method = 'POST';


### PR DESCRIPTION
Add unique_args to sendgrid config
Allows you to attach an unlimited number of unique arguments to your email up to 10,000 bytes. The arguments are used only for tracking. Better than track by category