### PR TITLE
Bugfix: renamed addUniqueArg to addCustomArg

### DIFF
--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -216,7 +216,7 @@ Mailer.send = function (options, cb) { // eslint-disable-line
       //unique_args
       if (R.is(Array, options.sendGridConfig.unique_args)) {
         R.forEach(function eachUniqueArg(arg){
-          sendgridEmail.addUniqueArg(arg);
+          sendgridEmail.addCustomArg(arg);
         }, options.sendGridConfig.unique_args);
       }
       


### PR DESCRIPTION
The addUniqueArg property doesn't exists in the Sendgrid API, renamed to addCustomArg.

See: https://github.com/sendgrid/sendgrid-nodejs/blob/30c94631583581c4f82d65557c060d2753efb38d/examples/helpers/mail/example.js#L47