### PR TITLE
fix: Remove sendgrid respone.statusCode testing

### DIFF
--- a/lib/sendgrid.js
+++ b/lib/sendgrid.js
@@ -219,20 +219,13 @@ Mailer.send = function (options, cb) { // eslint-disable-line
           sendgridEmail.addCustomArg(arg);
         }, options.sendGridConfig.unique_args);
       }
-      
+
     }
     request = connector.sendgrid.emptyRequest();
     request.method = 'POST';
     request.path = '/v3/mail/send';
     request.body = sendgridEmail.toJSON();
-    connector.sendgrid.API(request, function sgCb(response){ // eslint-disable-line
-      var code = response && response.statusCode;
-      if (code && (code.toString() === "200" || code.toString() === "202")) {
-        fn(null, response);
-      } else {
-        fn(response);
-      }
-    });
+    connector.sendgrid.API(request, fn); // eslint-disable-line
   } else {
     process.nextTick(function nextTick() { // eslint-disable-line
       fn(null, options);


### PR DESCRIPTION
The callback signature for `connector.sendgrid.API(request, callback)` now supports 2 parameters: error and response. Therefore there is no need to test respone.statusCode against 200 and 202.